### PR TITLE
Fix build on OS X Mavericks

### DIFF
--- a/native/pom.xml
+++ b/native/pom.xml
@@ -45,7 +45,7 @@
                 <compilerparams>${additional.includes}</compilerparams>
                 <artifact>libjahspotify</artifact>
                 <packaging>so</packaging>
-                <additional.includes>-I/System/Library/Frameworks/JavaVM.framework/Headers -I${java.home}/../include -I${java.home}../include/darwin</additional.includes>
+                <additional.includes>-I/System/Library/Frameworks/JavaVM.framework/Headers -I${java.home}/../include -I${java.home}../include/darwin -I/System/Library/Frameworks/OpenAL.framework/Headers</additional.includes>
             </properties>
         </profile>
 

--- a/native/pom.xml
+++ b/native/pom.xml
@@ -42,9 +42,10 @@
             <properties>
                 <OS>mac</OS>
                 <linkeropts>-lspotify -lc -ldl -framework OpenAL</linkeropts>
+                <compilerparams>${additional.includes}</compilerparams>
                 <artifact>libjahspotify</artifact>
                 <packaging>so</packaging>
-                <additional.includes>-I/System/Library/Frameworks/JavaVM.framework/Headers</additional.includes>
+                <additional.includes>-I/System/Library/Frameworks/JavaVM.framework/Headers -I${java.home}/../include -I${java.home}../include/darwin</additional.includes>
             </properties>
         </profile>
 

--- a/native/src/main/native/src/Callbacks.c
+++ b/native/src/main/native/src/Callbacks.c
@@ -4,6 +4,9 @@
 #include <libspotify/api.h>
 #include <string.h>
 #include <stdlib.h>
+#ifdef __APPLE__
+#include <pthread.h>
+#endif
 
 #include "Callbacks.h"
 #include "JahSpotify.h"

--- a/native/src/main/native/src/openal-audio.c
+++ b/native/src/main/native/src/openal-audio.c
@@ -25,8 +25,13 @@
  * This file is part of the libspotify examples suite.
  */
 
+#ifndef __APPLE__
 #include <AL/al.h>
 #include <AL/alc.h>
+#else
+#include <al.h>
+#include <alc.h>
+#endif
 #include <errno.h>
 #include <math.h>
 #include <stdio.h>

--- a/native/src/main/native/src/openal-audio.c
+++ b/native/src/main/native/src/openal-audio.c
@@ -166,7 +166,7 @@ static void* audio_start(void *aux)
             if (error != AL_NO_ERROR)
             {
                 log_error("openal","audio_start","Error buffering: %s", alGetString(error));
-                return;
+                return NULL;
             }
 
             alSourceQueueBuffers(source, 1, &buffer);
@@ -175,7 +175,7 @@ static void* audio_start(void *aux)
             if (alGetError() != AL_NO_ERROR)
             {
                 log_error("openal","audio_start","Error queing buffering: %s", alGetString(error));
-                return;
+                return NULL;
             }
 
 


### PR DESCRIPTION
Hiya,

With these changes Jah'Spotify builds on OS X Mavericks, at least when using an Oracle JDK. Tested with JDK 1.7.0_45-b18, maven and libspotify from Homebrew.
